### PR TITLE
daemonize flag

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -313,6 +313,8 @@ This approach has the major security drawback that while this `aws-vault` server
 
 To use `--server`, AWS Vault needs root/administrator privileges in order to bind to the privileged port. AWS Vault runs a minimal proxy as the root user, proxying through to the real aws-vault instance.
 
+By default `--server` runs as a background daemon. To run this as a foreground process you may also pass in the `--no-daemonize` (or `-z`) flag to avoid this.
+
 #### `--ecs-server`
 
 An ECS credential server can also be used instead of the ec2 metadata server. The ECS Credential provider binds to a random, ephemeral port and requires an authorization token, which offer the following advantages over the EC2 Metadata provider:
@@ -501,4 +503,5 @@ aws-vault exec --server --prompt=osascript jonsmith -- open -a Lens
 ```
 * `--server`: starts the background server so that temporary credentials get refreshed automatically
 * `--prompt=osascript`: pop up a GUI for MFA prompts
+* `--no-daemonize`: do not run the server as a background daemon
 * `open -a Lens`: run the applications

--- a/server/ec2server.go
+++ b/server/ec2server.go
@@ -15,7 +15,7 @@ import (
 const ec2CredentialsServerAddr = "127.0.0.1:9099"
 
 // StartEc2CredentialsServer starts a EC2 Instance Metadata server and endpoint proxy
-func StartEc2CredentialsServer(creds *credentials.Credentials, region string) error {
+func StartEc2CredentialsServer(creds *credentials.Credentials, Daemonize bool, region string) error {
 	if !isProxyRunning() {
 		if err := StartEc2EndpointProxyServerProcess(); err != nil {
 			return err
@@ -26,7 +26,11 @@ func StartEc2CredentialsServer(creds *credentials.Credentials, region string) er
 	// SDKs seem to very aggressively timeout
 	_, _ = creds.Get()
 
-	startEc2CredentialsServer(creds, region)
+  	if Daemonize {
+  	  	go startEc2CredentialsServer(creds, region)
+  	} else {
+  	  	startEc2CredentialsServer(creds, region)
+  	}
 
 	return nil
 }

--- a/vault/config.go
+++ b/vault/config.go
@@ -26,6 +26,7 @@ const (
 
 // UseSession will disable the use of GetSessionToken when set to false
 var UseSession = true
+var Daemonize = true
 
 func init() {
 	ini.PrettyFormat = false


### PR DESCRIPTION
```
± ./aws-vault exec home --no-daemonize -- aws sts get-caller-identity
aws-vault: error: exec: Can't use --no-daemonize without --server

± ./aws-vault exec home --server
Password:
^C

± ./aws-vault exec home --no-daemonize --server
myoung@Marcs-MBP aws-vault %
```

both work via testing in a different tmux pane:

```
± aws sts get-caller-identity
{
    "UserId": "AIDAJ5LZT5GIKAAAAANJO",
    "Account": "1234567890",
    "Arn": "arn:aws:iam::1234567890:user/myoung"
}
```